### PR TITLE
Update sign.ts to return array of state objects, better than undefined return.

### DIFF
--- a/src/utils/sign.ts
+++ b/src/utils/sign.ts
@@ -19,6 +19,7 @@ export async function send2TransactionsListOneByOneWithErrorCatch(
   const signed = await wallet.signAllTransactions(trxs);
   console.info('----- Sign end -----');
 
+  const stateInfos: {state: string, msg: string, total: number}[] = [];
   for (let index = 0; index < signed.length; index++) {
     const signedTrx = signed[index];
     const txid = await connection.sendRawTransaction(signedTrx.serialize(), {
@@ -55,11 +56,14 @@ export async function send2TransactionsListOneByOneWithErrorCatch(
       console.info('----- Confirm Timeout -----', err);
       stateInfo.state = 'timeout';
       stateInfo.msg = err?.toString();
+    } finally {
+      stateInfos.push(stateInfo);
     }
 
     console.log('confirmResponse', stateInfo);
     if (onTrxConfirmed) {
       onTrxConfirmed(index, txid, stateInfo);
     }
+    return stateInfos;
   }
 }


### PR DESCRIPTION
No reason not to return the transaction states as an array. Much easier to use in code than having to use a nested function callback to get this data.
The nested function callbacks `onTrxConfirmed` is useful for other use cases, but for when you just want to get a list of states for your transaction, this is much easier.